### PR TITLE
Avoid caching Connection in ConnectionProvider

### DIFF
--- a/samples/play-jooq-sample/app/models/PlayConnectionProvider.java
+++ b/samples/play-jooq-sample/app/models/PlayConnectionProvider.java
@@ -15,21 +15,13 @@ import java.sql.SQLException;
  */
 public class PlayConnectionProvider implements ConnectionProvider {
 
-    private Connection connection = null;
-
     @Override
     public Connection acquire() throws DataAccessException {
-        if (connection == null) {
-            connection = DB.getConnection();
-        }
-        return connection;
+        return DB.getConnection();
     }
 
     @Override
-    public void release(Connection released) throws DataAccessException {
-        if (this.connection != released) {
-            throw new IllegalArgumentException("Expected " + this.connection + " but got " + released);
-        }
+    public void release(Connection connection) throws DataAccessException {
         try {
             connection.close();
             connection = null;


### PR DESCRIPTION
This practice has been seen a couple of times on the internet, in various sample projects, blog posts, etc. It is generally not a good idea to cache the Connection in a `ConnectionProvider`, as the `ConnectionProvider` should be stateless and threadsafe to be more generally useful, e.g. when injected via DI

For example, this user refers to your example and will probably get it wrong:
https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!msg/play-framework/tXvA76ZQsJs/BoznOslsHwAJ
